### PR TITLE
Identity is not the same thing as equality in Python

### DIFF
--- a/DjangoBlog/whoosh_cn_backend.py
+++ b/DjangoBlog/whoosh_cn_backend.py
@@ -624,7 +624,7 @@ class WhooshSearchBackend(BaseSearchBackend):
                     if string_key in index.fields and hasattr(index.fields[string_key], 'convert'):
                         # Special-cased due to the nature of KEYWORD fields.
                         if index.fields[string_key].is_multivalued:
-                            if value is None or len(value) is 0:
+                            if value is None or len(value) == 0:
                                 additional_fields[string_key] = []
                             else:
                                 additional_fields[string_key] = value.split(',')


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) F632 Use ==/!= to compare str, bytes, and int literals

$ __python__
```python
>>> 0 == 0.0
True
>>> 0 is 0.0
False
```