### PR TITLE
Travis CI: Add Python 3.7 to the testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: python
 python:
   - "3.5"
   - "3.6"
+matrix:
+  include:
+    - python: "3.7"
+      dist: xenial
 services:
   - mysql
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ matrix:
   include:
     - python: "3.7"
       dist: xenial
+  allow_failures:
+    - python: "3.7"
 services:
   - mysql
 env:


### PR DESCRIPTION
Run Python 3.7 tests in __allow_failures__ mode until we can find a fix.