### PR TITLE
Travis CI: Remove allow_failures on Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ matrix:
   include:
     - python: "3.7"
       dist: xenial
-  allow_failures:
-    - python: "3.7"
 services:
   - mysql
 env:


### PR DESCRIPTION
Tests are passing now.