### PR TITLE
消除时区警告

### DIFF
--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -2,11 +2,11 @@ from django.test import Client, RequestFactory, TestCase
 from blog.models import Article, Category, Tag
 from django.contrib.auth import get_user_model
 from DjangoBlog.utils import delete_view_cache, delete_sidebar_cache
-import datetime
 from accounts.models import BlogUser
 from django.urls import reverse
 from DjangoBlog.utils import *
 from django.conf import settings
+from django.utils import timezone
 
 
 # Create your tests here.
@@ -33,8 +33,8 @@ class AccountTest(TestCase):
 
         category = Category()
         category.name = "categoryaaa"
-        category.created_time = datetime.datetime.now()
-        category.last_mod_time = datetime.datetime.now()
+        category.created_time = timezone.now()
+        category.last_mod_time = timezone.now()
         category.save()
 
         article = Article()
@@ -80,8 +80,8 @@ class AccountTest(TestCase):
         delete_sidebar_cache(user.username)
         category = Category()
         category.name = "categoryaaa"
-        category.created_time = datetime.datetime.now()
-        category.last_mod_time = datetime.datetime.now()
+        category.created_time = timezone.now()
+        category.last_mod_time = timezone.now()
         category.save()
 
         article = Article()

--- a/blog/tests.py
+++ b/blog/tests.py
@@ -5,11 +5,11 @@ from DjangoBlog.utils import get_current_site, get_md5
 from blog.forms import BlogSearchForm
 from django.core.paginator import Paginator
 from blog.templatetags.blog_tags import load_pagination_info, load_articletags
-import datetime
 from accounts.models import BlogUser
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.conf import settings
 from django.urls import reverse
+from django.utils import timezone
 import os
 
 
@@ -42,8 +42,8 @@ class ArticleTest(TestCase):
 
         category = Category()
         category.name = "category"
-        category.created_time = datetime.datetime.now()
-        category.last_mod_time = datetime.datetime.now()
+        category.created_time = timezone.now()
+        category.last_mod_time = timezone.now()
         category.save()
 
         tag = Tag()

--- a/comments/tests.py
+++ b/comments/tests.py
@@ -3,7 +3,7 @@ from blog.models import Article, Category, Tag
 from django.contrib.auth import get_user_model
 from DjangoBlog.utils import get_current_site
 from django.urls import reverse
-import datetime
+from django.utils import timezone
 from accounts.models import BlogUser
 from comments.templatetags.comments_tags import *
 from DjangoBlog.utils import get_max_articleid_commentid
@@ -27,8 +27,8 @@ class CommentsTest(TestCase):
 
         category = Category()
         category.name = "categoryccc"
-        category.created_time = datetime.datetime.now()
-        category.last_mod_time = datetime.datetime.now()
+        category.created_time = timezone.now()
+        category.last_mod_time = timezone.now()
         category.save()
 
         article = Article()

--- a/owntracks/views.py
+++ b/owntracks/views.py
@@ -103,6 +103,7 @@ def get_datas(request):
         date = list(map(lambda x: int(x), request.GET.get('date').split('-')))
         querydate = django.utils.timezone.datetime(
             date[0], date[1], date[2], 0, 0, 0)
+    querydate = django.utils.timezone.make_aware(querydate)
     nextdate = querydate + datetime.timedelta(days=1)
     models = OwnTrackLog.objects.filter(
         created_time__range=(querydate, nextdate))

--- a/servermanager/tests.py
+++ b/servermanager/tests.py
@@ -1,7 +1,7 @@
 from django.test import Client, RequestFactory, TestCase
 from DjangoBlog.utils import get_current_site
 from .models import commands
-import datetime
+from django.utils import timezone
 from accounts.models import BlogUser
 from blog.models import Category, Article
 from .robot import search, category, recents
@@ -32,8 +32,8 @@ class ServerManagerTest(TestCase):
 
         c = Category()
         c.name = "categoryccc"
-        c.created_time = datetime.datetime.now()
-        c.last_mod_time = datetime.datetime.now()
+        c.created_time = timezone.now()
+        c.last_mod_time = timezone.now()
         c.save()
 
         article = Article()


### PR DESCRIPTION
执行 `python manage.py test` 时会有警告：
```
.env38\lib\site-packages\django\db\models\fields\__init__.py:1365: 
RuntimeWarning: DateTimeField OwnTrackLog.created_time received a naive datetime
 (2018-02-26 00:00:00) while time zone support is active.
```