### PR TITLE
移除重复变量，使用BASE_DIR取代SITE_ROOT

### DIFF
--- a/DjangoBlog/settings.py
+++ b/DjangoBlog/settings.py
@@ -38,9 +38,6 @@ ALLOWED_HOSTS = ['*', '127.0.0.1', 'example.com']
 # Application definition
 
 
-SITE_ROOT = os.path.dirname(os.path.abspath(__file__))
-SITE_ROOT = os.path.abspath(os.path.join(SITE_ROOT, '../'))
-
 INSTALLED_APPS = [
     # 'django.contrib.admin',
     'django.contrib.admin.apps.SimpleAdminConfig',
@@ -162,7 +159,7 @@ HAYSTACK_SIGNAL_PROCESSOR = 'haystack.signals.RealtimeSignalProcessor'
 AUTHENTICATION_BACKENDS = [
     'accounts.user_login_backend.EmailOrUsernameModelBackend']
 
-STATIC_ROOT = os.path.join(SITE_ROOT, 'collectedstatic')
+STATIC_ROOT = os.path.join(BASE_DIR, 'collectedstatic')
 
 STATIC_URL = '/static/'
 STATICFILES = os.path.join(BASE_DIR, 'static')
@@ -293,6 +290,6 @@ COMPRESS_JS_FILTERS = [
     'compressor.filters.jsmin.JSMinFilter'
 ]
 
-MEDIA_ROOT = os.path.join(SITE_ROOT, 'uploads')
+MEDIA_ROOT = os.path.join(BASE_DIR, 'uploads')
 MEDIA_URL = '/media/'
 X_FRAME_OPTIONS = 'SAMEORIGIN'


### PR DESCRIPTION
`BASE_DIR` 与 `SITE_ROOT` 值一致， `SITE_ROOT` 变量可追溯到commit f9a939d6aeeb2a9a2905057e59826ea7e5f1253b ，完全可以用 `BASE_DIR` 替代。