### PR TITLE
修复docker的支持

### DIFF
--- a/docker-support/Dockerfile
+++ b/docker-support/Dockerfile
@@ -3,6 +3,10 @@ WORKDIR /app
 
 COPY ./requirements.txt .
 
+RUN echo "https://mirror.tuna.tsinghua.edu.cn/alpine/v3.11/main" > /etc/apk/repositories \
+&& echo "https://mirror.tuna.tsinghua.edu.cn/alpine/v3.11/community" >> /etc/apk/repositories \
+&& echo "https://mirror.tuna.tsinghua.edu.cn/alpine/edge/testing" >> /etc/apk/repositories
+
 RUN apk --update --no-cache add python3 py3-pip py-gunicorn nginx mariadb-connector-c \
     && apk --update --no-cache add --virtual .build-deps \
         tzdata \
@@ -22,9 +26,9 @@ RUN apk --update --no-cache add python3 py3-pip py-gunicorn nginx mariadb-connec
         tcl-dev \
         harfbuzz-dev \
         fribidi-dev \
-	&& pip3 install --upgrade pip setuptools gevent \
+        && pip3 install --upgrade pip \
 	&& mkdir -p /run/nginx \
-    && pip3 install -r requirements.txt \
+    && pip3 install -r requirements.txt -i https://pypi.tuna.tsinghua.edu.cn/simple \
     && cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime \
     && echo "Asia/Shanghai" > /etc/timezone \
     && apk del .build-deps
@@ -62,4 +66,4 @@ ENV DJANGO_WXADMIN_PASSWORD DJANGO_BLOG_CHANGE_ME
 ENV DJANGO_WEROBOT_TOKEN DJANGO_BLOG_CHANGE_ME
 
 EXPOSE 80
-ENTRYPOINT ["./docker-support/entrypoint.sh"]
+ENTRYPOINT ["sh","./docker-support/entrypoint.sh"]

--- a/docker-support/README.md
+++ b/docker-support/README.md
@@ -24,6 +24,7 @@ docker build -f .\docker-support\Dockerfile -t <你的 Docker Hub 用户名>/dja
 ```shell script
 docker run -it --rm <你的 Docker Hub 用户名>/django_blog:latest <指令>
 ```
+##### DJANGO_MYSQL_HOST获取：宿主机输入 ifconfig 中的docker0的inet addr
 
 例如：
 

--- a/docker-support/README.md
+++ b/docker-support/README.md
@@ -24,7 +24,7 @@ docker build -f .\docker-support\Dockerfile -t <你的 Docker Hub 用户名>/dja
 ```shell script
 docker run -it --rm <你的 Docker Hub 用户名>/django_blog:latest <指令>
 ```
-##### DJANGO_MYSQL_HOST获取：宿主机输入 ifconfig 中的docker0的inet addr
+### DJANGO_MYSQL_HOST获取：宿主机输入 ifconfig 中的docker0的inet addr
 
 例如：
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,3 +36,4 @@ requests==2.24.0
 rjsmin==1.1.0
 WeRoBot==1.12.0
 Whoosh==2.7.4
+gevent==1.4.0


### PR DESCRIPTION
1. 修改apk和pip下载的源，提高下载速度

2.  dockerfile的ENTRYPOINT需要“sh" ，启动doocker不然运行时提示没有权限

3. gevent在docker一直无法下载，放在requirements.txt就可以解决

搞了一两天终于使用docker部署完成 ，谢谢作者的开源