### PR TITLE
更新域名备案超链接

### DIFF
--- a/templates/share_layout/footer.html
+++ b/templates/share_layout/footer.html
@@ -36,7 +36,7 @@
     </div>
     {% if BEIAN_CODE %}
         <div class="site-info" style="text-align: center">
-            <a href="http://www.beian.miit.gov.cn/" rel="nofollow" target="_blank">
+            <a href="https://beian.miit.gov.cn/" rel="nofollow" target="_blank">
                 <p style=" height:20px;line-height:20px;margin: 0px 0px 0px 5px; color:#939393;">
                     {{ BEIAN_CODE }}
                 </p>


### PR DESCRIPTION
<1> 背景&影响
最近我用DjangoBlog搭建了博客，域名备案的超链接设置有问题。
目前使用的是[http://www.beian.miit.gov.cn](http://www.beian.miit.gov.cn)，会导致跳转页面失败。
为了顺利通过域名备案申请，需要将该超链接更新[https://beian.miit.gov.cn](https://beian.miit.gov.cn)。

<2> 解决方案
考虑到国家备案站点的域名长期不会变化，我们不需要支持动态配置，只需要在templates/share_layout/footer.html更新为正确的超链接。







