### PR TITLE
feat(admin):实现分类顺序控制功能

### DIFF
--- a/blog/admin.py
+++ b/blog/admin.py
@@ -111,6 +111,7 @@ class TagAdmin(admin.ModelAdmin):
 
 
 class CategoryAdmin(admin.ModelAdmin):
+    list_display = ('name', 'parent_category', 'index')
     exclude = ('slug', 'last_mod_time', 'created_time')
 
 

--- a/blog/models.py
+++ b/blog/models.py
@@ -174,9 +174,10 @@ class Category(BaseModel):
         null=True,
         on_delete=models.CASCADE)
     slug = models.SlugField(default='no-slug', max_length=60, blank=True)
+    index = models.IntegerField(default=0, verbose_name="权重排序-越大越靠前")
 
     class Meta:
-        ordering = ['name']
+        ordering = ['-index']
         verbose_name = "分类"
         verbose_name_plural = verbose_name
 


### PR DESCRIPTION
# PR内容
1. issue链接: https://github.com/liangliangyy/DjangoBlog/issues/490
2. 简单解决了分类的排序问题

## 解决方案
1. 在 Categor 里增加了一个 Index 权重字段，根据权重的大小，来控制分类的顺序

## 自测
1. admin 里面的排序
![image](https://user-images.githubusercontent.com/49054842/133015074-c19a8d63-84de-4336-8e53-ed95355cd7b7.png)
2. 首页里面的排序
![image](https://user-images.githubusercontent.com/49054842/133015132-a70ed780-af61-42af-9e66-4989a605245c.png)
3. 对于 Index 字段的修改
![image](https://user-images.githubusercontent.com/49054842/133015210-f39127a4-4fa6-4fbc-bd04-e5eacdd42e18.png)
