### PR TITLE
feat(account):实现忘记密码功能

### DIFF
--- a/DjangoBlog/blog_signals.py
+++ b/DjangoBlog/blog_signals.py
@@ -12,24 +12,23 @@
 @file: blog_signals.py
 @time: 2017/8/12 上午10:18
 """
-import django
+import _thread
+import logging
+
 import django.dispatch
 from django.dispatch import receiver
 from django.conf import settings
 from django.contrib.admin.models import LogEntry
-from DjangoBlog.utils import get_current_site
 from django.core.mail import EmailMultiAlternatives
 from django.db.models.signals import post_save
-from django.contrib.auth.signals import user_logged_in, user_logged_out, user_login_failed
+from django.contrib.auth.signals import user_logged_in, user_logged_out
 
-from DjangoBlog.utils import cache, send_email, expire_view_cache, delete_sidebar_cache, delete_view_cache
-from DjangoBlog.spider_notify import SpiderNotify
 from oauth.models import OAuthUser
-from blog.models import Article, Category, Tag, Links, SideBar, BlogSettings
 from comments.models import Comment
 from comments.utils import send_comment_email
-import _thread
-import logging
+from DjangoBlog.utils import get_current_site
+from DjangoBlog.utils import cache, expire_view_cache, delete_sidebar_cache, delete_view_cache
+from DjangoBlog.spider_notify import SpiderNotify
 
 logger = logging.getLogger(__name__)
 
@@ -61,7 +60,7 @@ def send_email_signal_handler(sender, **kwargs):
         result = msg.send()
         log.send_result = result > 0
     except Exception as e:
-        logger.error(e)
+        logger.error(f"失败邮箱号: {emailto}, {e}")
         log.send_result = False
     log.save()
 

--- a/accounts/email.py
+++ b/accounts/email.py
@@ -1,0 +1,51 @@
+import typing
+import random
+import string
+from datetime import timedelta
+
+from django.core.cache import cache
+from DjangoBlog.utils import send_email
+
+_code_ttl = timedelta(minutes=5)
+
+
+def generate_code() -> str:
+    """生成随机数验证码"""
+    return ''.join(random.sample(string.digits, 6))
+
+
+def send(to_mail: str, code: str, subject: str = "邮件验证码"):
+    """发送重设密码验证码
+    Args:
+        to_mail: 接受邮箱
+        subject: 邮件主题
+        code: 验证码
+    """
+    html_content = f"您正在重设密码，验证码为：{code}, 5分钟内有效，请妥善保管"
+    send_email([to_mail], subject, html_content)
+
+
+def verify(email: str, code: str) -> typing.Optional[str]:
+    """验证code是否有效
+    Args:
+        email: 请求邮箱
+        code: 验证码
+    Return:
+        如果有错误就返回错误str
+    Node:
+        这里的错误处理不太合理，应该采用raise抛出
+        否测调用方也需要对error进行处理
+    """
+    cache_code = get_code(email)
+    if cache_code != code:
+        return "验证码错误"
+
+
+def set_code(email: str, code: str):
+    """设置code"""
+    cache.set(email, code, _code_ttl.seconds)
+
+
+def get_code(email: str) -> typing.Optional[str]:
+    """获取code"""
+    return cache.get(email)

--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -1,12 +1,12 @@
-from django.test import Client, RequestFactory, TestCase
-from blog.models import Article, Category, Tag
-from django.contrib.auth import get_user_model
-from DjangoBlog.utils import delete_view_cache, delete_sidebar_cache
-from accounts.models import BlogUser
 from django.urls import reverse
-from DjangoBlog.utils import *
 from django.conf import settings
 from django.utils import timezone
+from django.test import Client, RequestFactory, TestCase
+
+from accounts.models import BlogUser
+from DjangoBlog.utils import *
+from blog.models import Article, Category
+from . import email
 
 
 # Create your tests here.
@@ -15,6 +15,12 @@ class AccountTest(TestCase):
     def setUp(self):
         self.client = Client()
         self.factory = RequestFactory()
+        self.blog_user = BlogUser.objects.create_user(
+            username="test",
+            email="admin@admin.com",
+            password="12345678"
+        )
+        self.new_test = "xxx123--="
 
     def test_validate_account(self):
         site = get_current_site().domain
@@ -111,3 +117,101 @@ class AccountTest(TestCase):
 
         response = self.client.get(article.get_admin_url())
         self.assertIn(response.status_code, [301, 302, 200])
+
+    def test_verify_email_code(self):
+        to_email = "admin@admin.com"
+        code = email.generate_code()
+        email.set_code(to_email, code)
+        email.send(to_email, code)
+
+        err = email.verify("admin@admin.com", code)
+        self.assertEqual(err, None)
+
+        err = email.verify("admin@123.com", code)
+        self.assertEqual(type(err), str)
+
+    def test_forget_password_email_code_success(self):
+        resp = self.client.post(
+            path=reverse("account:forget_password_code"),
+            data=dict(email="admin@admin.com")
+        )
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.content.decode("utf-8"), "ok")
+
+    def test_forget_password_email_code_fail(self):
+        resp = self.client.post(
+            path=reverse("account:forget_password_code"),
+            data=dict()
+        )
+        self.assertEqual(resp.content.decode("utf-8"), "错误的邮箱")
+
+        resp = self.client.post(
+            path=reverse("account:forget_password_code"),
+            data=dict(email="admin@com")
+        )
+        self.assertEqual(resp.content.decode("utf-8"), "错误的邮箱")
+
+    def test_forget_password_email_success(self):
+        code = email.generate_code()
+        email.set_code(self.blog_user.email, code)
+        data = dict(
+            new_password1=self.new_test,
+            new_password2=self.new_test,
+            email=self.blog_user.email,
+            code=code,
+        )
+        resp = self.client.post(
+            path=reverse("account:forget_password"),
+            data=data
+        )
+        self.assertEqual(resp.status_code, 302)
+
+        # 验证用户密码是否修改成功
+        blog_user = BlogUser.objects.filter(
+            email=self.blog_user.email,
+        ).first()  # type: BlogUser
+        self.assertNotEqual(blog_user, None)
+        self.assertEqual(blog_user.check_password(data["new_password1"]), True)
+
+    def test_forget_password_email_not_user(self):
+        data = dict(
+            new_password1=self.new_test,
+            new_password2=self.new_test,
+            email="123@123.com",
+            code="123456",
+        )
+        resp = self.client.post(
+            path=reverse("account:forget_password"),
+            data=data
+        )
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertFormError(
+            response=resp,
+            form="form",
+            field="email",
+            errors="未找到邮箱对应的用户"
+        )
+
+    def test_forget_password_email_code_error(self):
+        code = email.generate_code()
+        email.set_code(self.blog_user.email, code)
+        data = dict(
+            new_password1=self.new_test,
+            new_password2=self.new_test,
+            email=self.blog_user.email,
+            code="111111",
+        )
+        resp = self.client.post(
+            path=reverse("account:forget_password"),
+            data=data
+        )
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertFormError(
+            response=resp,
+            form="form",
+            field="code",
+            errors="验证码错误"
+        )

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -14,10 +14,10 @@
 """
 
 from django.conf.urls import url
-from django.contrib.auth import views as auth_view
 from django.urls import path
-from . import views
+
 from .forms import LoginForm
+from . import views
 
 app_name = "accounts"
 
@@ -33,4 +33,11 @@ urlpatterns = [url(r'^login/$',
                    name='logout'),
                path(r'account/result.html',
                     views.account_result,
-                    name='result')]
+                    name='result'),
+               url(r'^forget_password/$',
+                   views.ForgetPasswordView.as_view(),
+                   name='forget_password'),
+               url(r'^forget_password_code/$',
+                   views.ForgetPasswordEmailCode.as_view(),
+                   name='forget_password_code'),
+               ]

--- a/blog/static/account/css/account.css
+++ b/blog/static/account/css/account.css
@@ -1,0 +1,9 @@
+.button {
+    border: none;
+    padding: 4px 80px;
+    text-align: center;
+    text-decoration: none;
+    display: inline-block;
+    font-size: 16px;
+    margin: 4px 2px;
+}

--- a/blog/static/account/js/account.js
+++ b/blog/static/account/js/account.js
@@ -1,0 +1,47 @@
+let wait = 60;
+
+function time(o) {
+    if (wait == 0) {
+        o.removeAttribute("disabled");
+        o.value = "获取验证码";
+        wait = 60
+        return false
+    } else {
+        o.setAttribute("disabled", true);
+        o.value = "重新发送(" + wait + ")";
+        wait--;
+        setTimeout(function () {
+                time(o)
+            },
+            1000)
+    }
+}
+
+document.getElementById("btn").onclick = function () {
+    let id_email = $("#id_email")
+    let token = $("*[name='csrfmiddlewaretoken']").val()
+    let ts = this
+    let myErr = $("#myErr")
+    $.ajax(
+        {
+            url: "/forget_password_code/",
+            type: "POST",
+            data: {
+                "email": id_email.val(),
+                "csrfmiddlewaretoken": token
+            },
+            success: function (result) {
+                if (result != "ok") {
+                    myErr.remove()
+                    id_email.after("<ul className='errorlist' id='myErr'><li>" + result + "</li></ul>")
+                    return
+                }
+                myErr.remove()
+                time(ts)
+            },
+            error: function (e) {
+                alert("发送失败,请重试")
+            }
+        }
+    );
+}

--- a/templates/account/forget_password.html
+++ b/templates/account/forget_password.html
@@ -1,0 +1,29 @@
+{% extends 'share_layout/base_account.html' %}
+{% load static %}
+{% block content %}
+    <div class="container">
+
+        <h2 class="form-signin-heading text-center">忘记密码</h2>
+
+        <div class="card card-signin">
+            <img class="img-circle profile-img" src="{% static 'blog/img/avatar.png' %}" alt="">
+            <form class="form-signin" action="{% url 'account:forget_password' %}" method="post">
+                {% csrf_token %}
+                {{ form.non_field_errors }}
+                {% for field in form %}
+                    {{ field }}
+                    {{ field.errors }}
+                {% endfor %}
+            <input type="button" class="button" id="btn" value="获取验证码">
+            <button class="btn btn-lg btn-primary btn-block" type="submit">提交</button>
+            </form>
+        </div>
+
+        <p class="text-center">
+            <a href="/">Home Page</a>
+            |
+            <a href="{% url "account:login" %}">login page</a>
+        </p>
+
+    </div> <!-- /container -->
+{% endblock %}

--- a/templates/account/login.html
+++ b/templates/account/login.html
@@ -37,6 +37,8 @@
             <a href="{% url "account:register" %}">Create Account</a>
             |
             <a href="/">Home Page</a>
+            |
+            <a href="{% url "account:forget_password" %}">忘记密码</a>
         </p>
 
     </div> <!-- /container -->

--- a/templates/share_layout/base_account.html
+++ b/templates/share_layout/base_account.html
@@ -11,6 +11,7 @@
     <link rel="icon" href="../../favicon.ico">
     <meta name="robots" content="noindex">
     <title>{{ SITE_NAME }} | {{ SITE_DESCRIPTION }}</title>
+    <link href="{% static 'account/css/account.css' %}" rel="stylesheet">
     {% load compress %}
     {% compress css %}
         <!-- Bootstrap core CSS -->
@@ -41,4 +42,6 @@
 <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
 
 </body>
+    <script type="text/javascript" src="{% static 'blog/js/jquery-3.6.0.min.js' %}"></script>
+    <script src="{% static 'account/js/account.js' %}" type="text/javascript"></script>
 </html>


### PR DESCRIPTION
# PR内容
1. issue链接:https://github.com/liangliangyy/DjangoBlog/issues/404
2. 实现了忘记密码的功能

## 实现方案
1. 因为注册时用的是邮箱，所以忘记密码时也用邮箱来做身份认证，会给邮箱发送一个验证码，如果输入的是发送的验证码，并且这个邮箱注册过，就可以设置新的密码，否则不行🙅🙅‍♂️
2. 成功以后，会跳转到登陆页面
3. 在写代码时，我发现有包导入了但没用，我删除了这些没用的包，并且把导包的顺序改了一下。如果有什么问题的话可以评论一下，我会去修改

## 自测
1. 页面样例
![image](https://user-images.githubusercontent.com/49054842/133229998-f1113e07-205e-4f23-90dc-1a5b5ff7e7f8.png)
2. 报错样例
![image](https://user-images.githubusercontent.com/49054842/133230216-76fc148a-7c94-40af-8b69-3c5f5d644398.png)
3. 验证码样例
![image](https://user-images.githubusercontent.com/49054842/133230686-43cb9228-fe24-461e-9e0a-94683c4de150.png)