### PR TITLE
fix(test):修复请求python.org超时,导致测试失败问题

### DIFF
--- a/blog/tests.py
+++ b/blog/tests.py
@@ -171,7 +171,7 @@ class ArticleTest(TestCase):
     def test_image(self):
         import requests
         rsp = requests.get(
-            'https://www.python.org/static/img/python-logo@2x.png')
+            'https://www.python-china.com/static/images/logo.png')
         imagepath = os.path.join(settings.BASE_DIR, 'python.png')
         with open(imagepath, 'wb') as file:
             file.write(rsp.content)
@@ -189,7 +189,7 @@ class ArticleTest(TestCase):
         from DjangoBlog.utils import save_user_avatar, send_email
         send_email(['qq@qq.com'], 'testTitle', 'testContent')
         save_user_avatar(
-            'https://www.python.org/static/img/python-logo@2x.png')
+            'https://www.python-china.com/static/images/logo.png')
 
     def test_errorpage(self):
         rsp = self.client.get('/eee')


### PR DESCRIPTION
# PR内容
1. 我在运行测试的时候，偶尔会遇到请求 www.python.org 超时的情况，我仔细看了测试，是去官网请求一个 python 图标，为了保证不再出现这个问题，我把 logo 图片换到了 www.python-china.com 下

## 问题图片
![image](https://user-images.githubusercontent.com/49054842/133239667-0909927a-fa0a-4458-8bd8-e45428b0a016.png)
