### PR TITLE
添加docker-compose本地上传文件卷

### DIFF
--- a/docker-compose.es.yml
+++ b/docker-compose.es.yml
@@ -30,6 +30,7 @@ services:
       - "8000:8000"
     volumes:
       - ./collectedstatic:/code/djangoblog/collectedstatic
+      - ./uploads:/code/djangoblog/uploads
     environment:
       - DJANGO_MYSQL_DATABASE=djangoblog
       - DJANGO_MYSQL_USER=root

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
     volumes:
       - ./collectedstatic:/code/djangoblog/collectedstatic
       - ./logs:/code/djangoblog/logs
+      - ./uploads:/code/djangoblog/uploads
     environment:
       - DJANGO_MYSQL_DATABASE=djangoblog
       - DJANGO_MYSQL_USER=root


### PR DESCRIPTION
用docker-compose部署项目后，在Markdown Editor中使用本地上传功能上传的图片或文件被保存在了容器中而没有对应的卷将数据映射到容器外，在执行`docker-compose down`命令后上传的文件或图片会丢失。在docker-compose.es.yml文件和docker-compose.yml文件中添加卷以映射被上传的数据。