### PR TITLE
load environment variable from .env file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,5 @@ uploads/
 settings_production.py
 werobot_session.db
 bin/datas/
+
+.env*

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ mysql客户端从`pymysql`修改成了`mysqlclient`，具体请参考 [pypi](htt
 
 ## 运行
 
- 修改`djangoblog/setting.py` 修改数据库配置，如下所示：
+修改`djangoblog/setting.py` 修改数据库配置，如下所示：
 
 ```python
 DATABASES = {
@@ -54,6 +54,16 @@ DATABASES = {
         'PORT': 3306,
     }
 }
+```
+
+或者在项目根目录，创建`.env`文件，将对应的数据库配置信息填入即可，如下所示：
+
+```python
+DJANGO_MYSQL_DATABASE=djangoblog
+DJANGO_MYSQL_USER=root
+DJANGO_MYSQL_PASSWORD=password
+DJANGO_MYSQL_HOST=127.0.0.1
+DJANGO_MYSQL_PORT=3306
 ```
 
 ### 创建数据库

--- a/djangoblog/settings.py
+++ b/djangoblog/settings.py
@@ -14,6 +14,9 @@ import sys
 
 from django.utils.translation import gettext_lazy as _
 
+from dotenv import load_dotenv
+
+load_dotenv()
 
 def env_to_bool(env, default):
     str_val = os.environ.get(env)

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ Whoosh==2.7.4
 user-agents==2.2.0
 redis==5.0.1
 openai==0.28.1
+python-dotenv==1.0.1


### PR DESCRIPTION
引入了 python-dotenv 库，在项目启动时候对 .env 文件进行加载。

这样用户直接配置 .env 文件中对应的数据库条目即可，不用直接修改 `settings.py` 文件

同时更新了 README 对应部分的描述