### PR TITLE
Potential fix for code scanning alert no. 23: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/djangoblog/utils.py
+++ b/djangoblog/utils.py
@@ -8,7 +8,7 @@ import random
 import string
 import uuid
 from hashlib import sha256
-
+import hmac
 import bleach
 import markdown
 import requests
@@ -26,8 +26,11 @@ def get_max_articleid_commentid():
     return (Article.objects.latest().pk, Comment.objects.latest().pk)
 
 
-def get_sha256(str):
-    m = sha256(str.encode('utf-8'))
+def get_sha256(message):
+    # Use HMAC-SHA256 with the Django SECRET_KEY for integrity protection
+    key = settings.SECRET_KEY.encode('utf-8')
+    msg = message.encode('utf-8')
+    m = hmac.new(key, msg, sha256)
     return m.hexdigest()
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/liangliangyy/DjangoBlog/security/code-scanning/23](https://github.com/liangliangyy/DjangoBlog/security/code-scanning/23)

To fix the problem, we should replace the use of plain SHA-256 in the `get_sha256` function with a more secure construction. Since the hash is used to protect the integrity of a confirmation link and includes a secret key, the best approach is to use HMAC with SHA-256, which is designed for this purpose. HMAC (Hash-based Message Authentication Code) uses a secret key and a hash function to produce a secure hash that is resistant to brute-force and collision attacks, provided the key is secret and sufficiently random.

The changes required are:
- In `djangoblog/utils.py`, import the `hmac` module and update the `get_sha256` function to use HMAC with SHA-256, using the Django `settings.SECRET_KEY` as the key.
- Update all calls to `get_sha256` to pass only the message to be signed (the identifier), and use the secret key inside the function.

No changes are needed in `oauth/tests.py` unless the signature generation logic changes, but the function interface remains the same.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
