### PR TITLE
Potential fix for code scanning alert no. 23: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/djangoblog/utils.py
+++ b/djangoblog/utils.py
@@ -7,7 +7,8 @@ import os
 import random
 import string
 import uuid
-from hashlib import sha256
+import hashlib
+import hmac
 
 import bleach
 import markdown
@@ -26,9 +27,10 @@ def get_max_articleid_commentid():
     return (Article.objects.latest().pk, Comment.objects.latest().pk)
 
 
-def get_sha256(str):
-    m = sha256(str.encode('utf-8'))
-    return m.hexdigest()
+def get_sha256(value):
+    key = settings.SECRET_KEY.encode('utf-8')
+    msg = str(value).encode('utf-8')
+    return hmac.new(key, msg, hashlib.sha256).hexdigest()
 
 
 def cache_decorator(expiration=3 * 60):
@@ -42,7 +44,7 @@ def cache_decorator(expiration=3 * 60):
             if not key:
                 unique_str = repr((func, args, kwargs))
 
-                m = sha256(unique_str.encode('utf-8'))
+                m = hashlib.sha256(unique_str.encode('utf-8'))
                 key = m.hexdigest()
             value = cache.get(key)
             if value is not None:


### PR DESCRIPTION
Potential fix for [https://github.com/liangliangyy/DjangoBlog/security/code-scanning/23](https://github.com/liangliangyy/DjangoBlog/security/code-scanning/23)

In general, the fix is to avoid using a bare cryptographic hash (even SHA‑256) directly for security tokens tied to user identifiers or other sensitive data, and instead use a keyed construction such as HMAC with a strong hash function, or a framework‑provided signing API. For password hashing specifically, one should use a dedicated slow password hash (Argon2, PBKDF2, bcrypt, etc.); however, in this codebase `get_sha256` is not being used for password storage but for signing URLs, so HMAC is the appropriate improvement.

Best minimal fix without changing existing functionality:

- Change `get_sha256` in `djangoblog/utils.py` to compute an HMAC using Django’s `SECRET_KEY` as the key and SHA‑256 as the hash function, instead of a plain SHA‑256 over the input string.
- Keep the return type and interface the same (a hex string), so callers like the OAuth tests continue to work without changes.
- Also update the use of `sha256` in `cache_decorator` to avoid relying on the `from hashlib import sha256` import, since we will switch to importing `hashlib` instead. For cache keys, a plain SHA‑256 is fine, but we can call it as `hashlib.sha256` to match the new import style.

Concrete steps in `djangoblog/utils.py`:

1. Replace `from hashlib import sha256` with `import hashlib` and `import hmac`.
2. Redefine `get_sha256` to:

   ```python
   def get_sha256(value: str):
       key = settings.SECRET_KEY.encode('utf-8')
       msg = value.encode('utf-8')
       return hmac.new(key, msg, hashlib.sha256).hexdigest()
   ```

   This keeps the same API (`get_sha256(str) -> hex string`) but now uses a proper keyed MAC.

3. Update `cache_decorator`’s internal use of SHA‑256 to call `hashlib.sha256` instead of the now‑removed `sha256` symbol:

   ```python
   m = hashlib.sha256(unique_str.encode('utf-8'))
   ```

No changes are needed in `oauth/tests.py`, because the function name and return format remain identical.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
