### PR TITLE
.4062073974432528:2ae6069804f536b7259ed8a0d04757f2_69eca62da3c75e7cbf9565a9.69eca80da3c75e7cbf9565ab.69eca80deabebd4376584c56:Trae CN.T(2026/4/25 19:39:57)

### DIFF
--- a/blog/admin.py
+++ b/blog/admin.py
@@ -1,12 +1,41 @@
 from django import forms
 from django.contrib import admin
 from django.contrib.auth import get_user_model
+from django.db.models import Q
 from django.urls import reverse
 from django.utils.html import format_html
+from django.utils.timezone import now
 from django.utils.translation import gettext_lazy as _
 
 # Register your models here.
 from .models import Article, Category, Tag, Links, SideBar, BlogSettings
+
+
+class ScheduledPublishFilter(admin.SimpleListFilter):
+    title = _('scheduled publish status')
+    parameter_name = 'scheduled_status'
+
+    def lookups(self, request, model_admin):
+        return (
+            ('scheduled', _('Scheduled')),
+            ('past', _('Scheduled time passed')),
+            ('not_scheduled', _('Not scheduled')),
+        )
+
+    def queryset(self, request, queryset):
+        if self.value() == 'scheduled':
+            return queryset.filter(
+                scheduled_publish_time__isnull=False,
+                scheduled_publish_time__gt=now()
+            )
+        elif self.value() == 'past':
+            return queryset.filter(
+                scheduled_publish_time__isnull=False,
+                scheduled_publish_time__lte=now()
+            )
+        elif self.value() == 'not_scheduled':
+            return queryset.filter(scheduled_publish_time__isnull=True)
+        return queryset
 
 
 class ArticleForm(forms.ModelForm):
@@ -49,12 +78,15 @@ class ArticlelAdmin(admin.ModelAdmin):
         'author',
         'link_to_category',
         'creation_time',
+        'pub_time',
+        'scheduled_publish_time',
+        'scheduled_status_display',
         'views',
         'status',
         'type',
         'article_order')
     list_display_links = ('id', 'title')
-    list_filter = ('status', 'type', 'category')
+    list_filter = ('status', 'type', 'category', ScheduledPublishFilter)
     date_hierarchy = 'creation_time'
     filter_horizontal = ('tags',)
     exclude = ('creation_time', 'last_modify_time')
@@ -65,6 +97,17 @@ class ArticlelAdmin(admin.ModelAdmin):
         close_article_commentstatus,
         open_article_commentstatus]
     raw_id_fields = ('author', 'category',)
+    fieldsets = (
+        (None, {
+            'fields': ('title', 'body', 'status', 'pub_time', 'scheduled_publish_time')
+        }),
+        (_('Classification'), {
+            'fields': ('category', 'tags', 'type', 'article_order', 'author')
+        }),
+        (_('Other Settings'), {
+            'fields': ('comment_status', 'show_toc', 'views')
+        }),
+    )
 
     def link_to_category(self, obj):
         info = (obj.category._meta.app_label, obj.category._meta.model_name)
@@ -72,6 +115,23 @@ class ArticlelAdmin(admin.ModelAdmin):
         return format_html(u'<a href="%s">%s</a>' % (link, obj.category.name))
 
     link_to_category.short_description = _('category')
+
+    def scheduled_status_display(self, obj):
+        """显示定时发布状态"""
+        if not obj.is_scheduled_publish():
+            return format_html('<span style="color: #666;">{}</span>', _('Not scheduled'))
+        if obj.is_past_scheduled_time():
+            if obj.status == 'p':
+                return format_html('<span style="color: #0a0;">{}</span>', _('Published'))
+            else:
+                return format_html('<span style="color: #a00;">{}</span>', _('Scheduled time passed'))
+        return format_html(
+            '<span style="color: #00a; font-weight: bold;">{}</span>',
+            _('Scheduled')
+        )
+
+    scheduled_status_display.short_description = _('scheduled status')
+    scheduled_status_display.admin_order_field = 'scheduled_publish_time'
 
     def get_form(self, request, obj=None, **kwargs):
         form = super(ArticlelAdmin, self).get_form(request, obj, **kwargs)

--- a/blog/management/commands/publish_scheduled_articles.py
+++ b/blog/management/commands/publish_scheduled_articles.py
@@ -1,0 +1,47 @@
+import logging
+
+from django.core.management.base import BaseCommand
+from django.utils.timezone import now
+from django.utils.translation import gettext_lazy as _
+
+from blog.models import Article
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = _('Automatically publish articles whose scheduled publish time has passed')
+
+    def handle(self, *args, **options):
+        current_time = now()
+        
+        articles_to_publish = Article.objects.filter(
+            status='d',
+            scheduled_publish_time__isnull=False,
+            scheduled_publish_time__lte=current_time
+        )
+        
+        count = 0
+        for article in articles_to_publish:
+            article.status = 'p'
+            if not article.pub_time or article.pub_time < article.scheduled_publish_time:
+                article.pub_time = article.scheduled_publish_time
+            article.save()
+            count += 1
+            logger.info(f'Published scheduled article: {article.title} (ID: {article.id})')
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f'Published: {article.title} (ID: {article.id})'
+                )
+            )
+        
+        if count == 0:
+            self.stdout.write(
+                self.style.WARNING(_('No scheduled articles to publish at this time'))
+            )
+        else:
+            self.stdout.write(
+                self.style.SUCCESS(_(f'Successfully published {count} scheduled article(s)'))
+            )
+        
+        return count

--- a/blog/migrations/0009_article_scheduled_publish_time.py
+++ b/blog/migrations/0009_article_scheduled_publish_time.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('blog', '0008_blogsettings_color_scheme'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='article',
+            name='scheduled_publish_time',
+            field=models.DateTimeField(
+                blank=True,
+                null=True,
+                help_text='If set, the article will be automatically published at this time. Can be set for both draft and published articles.',
+                verbose_name='scheduled publish time'
+            ),
+        ),
+    ]

--- a/blog/models.py
+++ b/blog/models.py
@@ -105,6 +105,13 @@ class Article(BaseModel):
         blank=False,
         null=False)
     tags = models.ManyToManyField('Tag', verbose_name=_('tag'), blank=True)
+    scheduled_publish_time = models.DateTimeField(
+        _('scheduled publish time'),
+        blank=True,
+        null=True,
+        help_text=_('If set, the article will be automatically published at this time. '
+                    'Can be set for both draft and published articles.')
+    )
 
     def body_to_string(self):
         return self.body
@@ -166,16 +173,30 @@ class Article(BaseModel):
         info = (self._meta.app_label, self._meta.model_name)
         return reverse('admin:%s_%s_change' % info, args=(self.pk,))
 
+    @classmethod
+    def get_published_queryset(cls):
+        """
+        获取实际上已发布的文章 QuerySet
+        条件：状态为已发布，且（没有设置定时发布 或 已过定时发布时间）
+        """
+        from django.db.models import Q
+        return cls.objects.filter(
+            Q(status='p') &
+            (Q(scheduled_publish_time__isnull=True) |
+             Q(scheduled_publish_time__lte=now()))
+        )
+
     @cache_decorator(expiration=CacheTimeout.HOUR_10)
     def next_article(self):
         # 下一篇
-        return Article.objects.filter(
-            id__gt=self.id, status='p').order_by('id').first()
+        return Article.get_published_queryset().filter(
+            id__gt=self.id).order_by('id').first()
 
     @cache_decorator(expiration=CacheTimeout.HOUR_10)
     def prev_article(self):
         # 前一篇
-        return Article.objects.filter(id__lt=self.id, status='p').first()
+        return Article.get_published_queryset().filter(
+            id__lt=self.id).order_by('-id').first()
 
     def get_first_image_url(self):
         """
@@ -186,6 +207,50 @@ class Article(BaseModel):
         if match:
             return match.group(1)
         return ""
+
+    def is_scheduled_publish(self):
+        """
+        判断文章是否设置了定时发布
+        """
+        return self.scheduled_publish_time is not None
+
+    def is_past_scheduled_time(self):
+        """
+        判断是否已过定时发布时间
+        """
+        if not self.is_scheduled_publish():
+            return False
+        return now() >= self.scheduled_publish_time
+
+    def should_be_published(self):
+        """
+        判断文章是否应该被自动发布
+        条件：设置了定时发布、已过定时时间、当前状态为草稿
+        """
+        return (self.is_scheduled_publish() and
+                self.is_past_scheduled_time() and
+                self.status == 'd')
+
+    def is_actually_published(self):
+        """
+        判断文章是否实际上已发布
+        条件：状态为已发布，且（没有设置定时发布 或 已过定时发布时间）
+        """
+        if self.status != 'p':
+            return False
+        if self.is_scheduled_publish():
+            return self.is_past_scheduled_time()
+        return True
+
+    def get_scheduled_status_display(self):
+        """
+        获取定时发布状态的显示文本
+        """
+        if not self.is_scheduled_publish():
+            return _('Not scheduled')
+        if self.is_past_scheduled_time():
+            return _('Scheduled time passed')
+        return _('Scheduled')
 
 
 class Category(BaseModel):

--- a/blog/views.py
+++ b/blog/views.py
@@ -69,8 +69,14 @@ class IndexView(OptimizedArticleQueryMixin, ArticleListView):
 
     def get_queryset_data(self):
         # 使用 Mixin 提供的优化查询方法
+        # 条件：状态为已发布，且（没有设置定时发布 或 已过定时发布时间）
+        from django.db.models import Q
+        from django.utils.timezone import now
         return self.get_optimized_article_queryset().filter(
-            type='a', status='p'
+            Q(type='a') &
+            Q(status='p') &
+            (Q(scheduled_publish_time__isnull=True) |
+             Q(scheduled_publish_time__lte=now()))
         )
 
     def get_queryset_cache_key(self):
@@ -190,8 +196,14 @@ class CategoryDetailView(SlugCachedMixin, OptimizedArticleQueryMixin, ArticleLis
         category = self.get_slug_object()
         categorynames = [c.name for c in category.get_sub_categorys()]
 
+        # 条件：状态为已发布，且（没有设置定时发布 或 已过定时发布时间）
+        from django.db.models import Q
+        from django.utils.timezone import now
         return self.get_optimized_article_queryset().filter(
-            category__name__in=categorynames, status='p'
+            Q(category__name__in=categorynames) &
+            Q(status='p') &
+            (Q(scheduled_publish_time__isnull=True) |
+             Q(scheduled_publish_time__lte=now()))
         )
 
     def get_queryset_cache_key(self):
@@ -236,8 +248,15 @@ class AuthorDetailView(OptimizedArticleQueryMixin, ArticleListView):
 
     def get_queryset_data(self):
         author_name = self.kwargs['author_name']
+        # 条件：状态为已发布，且（没有设置定时发布 或 已过定时发布时间）
+        from django.db.models import Q
+        from django.utils.timezone import now
         return self.get_optimized_article_queryset().filter(
-            author__username=author_name, type='a', status='p'
+            Q(author__username=author_name) &
+            Q(type='a') &
+            Q(status='p') &
+            (Q(scheduled_publish_time__isnull=True) |
+             Q(scheduled_publish_time__lte=now()))
         )
 
     def get_context_data(self, **kwargs):
@@ -269,8 +288,15 @@ class TagDetailView(SlugCachedMixin, OptimizedArticleQueryMixin, ArticleListView
     def get_queryset_data(self):
         # 使用 Mixin 缓存的对象，只查询一次
         tag = self.get_slug_object()
+        # 条件：状态为已发布，且（没有设置定时发布 或 已过定时发布时间）
+        from django.db.models import Q
+        from django.utils.timezone import now
         return self.get_optimized_article_queryset().filter(
-            tags__name=tag.name, type='a', status='p'
+            Q(tags__name=tag.name) &
+            Q(type='a') &
+            Q(status='p') &
+            (Q(scheduled_publish_time__isnull=True) |
+             Q(scheduled_publish_time__lte=now()))
         )
 
     def get_queryset_cache_key(self):
@@ -305,7 +331,14 @@ class ArchivesView(OptimizedArticleQueryMixin, ArticleListView):
     template_name = 'blog/article_archives.html'
 
     def get_queryset_data(self):
-        return self.get_optimized_article_queryset().filter(status='p')
+        # 条件：状态为已发布，且（没有设置定时发布 或 已过定时发布时间）
+        from django.db.models import Q
+        from django.utils.timezone import now
+        return self.get_optimized_article_queryset().filter(
+            Q(status='p') &
+            (Q(scheduled_publish_time__isnull=True) |
+             Q(scheduled_publish_time__lte=now()))
+        )
 
     def get_queryset_cache_key(self):
         return 'archives'

--- a/templates/blog/article_detail.html
+++ b/templates/blog/article_detail.html
@@ -31,6 +31,21 @@
                             {{ article.title }}
                         </h1>
 
+                        {# Scheduled Publish Notice #}
+                        {% load tz %}
+                        {% now "Y-m-d H:i:s" as current_time %}
+                        {% if article.scheduled_publish_time %}
+                            {% with article.scheduled_publish_time|date:"Y-m-d H:i:s" as scheduled_time %}
+                                {% if scheduled_time > current_time %}
+                                    <div class="mb-4 rounded-lg border border-yellow-200 bg-yellow-50 px-4 py-3 text-sm text-yellow-800 dark:border-yellow-800 dark:bg-yellow-900/20 dark:text-yellow-200">
+                                        <span class="font-semibold">{% trans 'Scheduled Publication' %}:</span>
+                                        {% trans 'This article will be published on' %}
+                                        <span class="font-medium">{{ article.scheduled_publish_time|date:"Y年m月d日 H:i" }}</span>
+                                    </div>
+                                {% endif %}
+                            {% endwith %}
+                        {% endif %}
+
                         {# Meta #}
                         <div class="mb-6 flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
                             <a href="{{ article.category.get_absolute_url }}"


### PR DESCRIPTION
实现文章的定时发布功能，包括：
1. 在文章模型中添加 scheduled_publish_time 字段
2. 创建管理命令自动发布到期的定时文章
3. 在文章详情页显示定时发布状态
4. 在后台添加定时发布状态筛选和显示
5. 修改所有文章查询逻辑以支持定时发布功能